### PR TITLE
Feat/add access to veda jhub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Deploy pgSTAC to AWS
 on:
   push:
     branches:
-      - feat/add-access-to-veda-jhub
       - main
   # enable a workflow to be triggered manually
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/add-access-to-veda-jhub
   # enable a workflow to be triggered manually
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ permissions:
       contents: read    # This is required for actions/checkout
 jobs:
   deploy-pgstac:
-    environment: dev
     runs-on: ubuntu-latest
     steps:
       - name: Git clone the repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/add-access-to-veda-jhub
   # enable a workflow to be triggered manually
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy pgSTAC to AWS
 on:
   push:
     branches:
+      - feat/add-access-to-veda-jhub
       - main
   # enable a workflow to be triggered manually
   workflow_dispatch:
@@ -19,6 +20,7 @@ permissions:
       contents: read    # This is required for actions/checkout
 jobs:
   deploy-pgstac:
+    environment: dev
     runs-on: ubuntu-latest
     steps:
       - name: Git clone the repository

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cdk.out
 __pycache__
 .ipynb_checkpoints
 *venv*
+cdk.context.json

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -63,7 +63,7 @@ export class eodcHubRole extends cdk.Stack {
     });
     eodcHubRole.addToPolicy(describeSecurityGroupsStatement);
     const securityGroupStatement = new cdk.aws_iam.PolicyStatement({
-      actions: ['ec2:ModifySecurityGroup*', 'ec2:AuthorizeSecurityGroupIngress', 'RevokeSecurityGroupIngress'],
+      actions: ['ec2:ModifySecurityGroup*', 'ec2:AuthorizeSecurityGroupIngress'],
       resources: [`arn:aws:ec2:${this.region}:${this.account}:security-group/${securityGroupId}`],
     });
     eodcHubRole.addToPolicy(securityGroupStatement);

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -63,7 +63,7 @@ export class eodcHubRole extends cdk.Stack {
     });
     eodcHubRole.addToPolicy(describeSecurityGroupsStatement);
     const securityGroupStatement = new cdk.aws_iam.PolicyStatement({
-      actions: ['ec2:ModifySecurityGroup*', 'ec2:AuthorizeSecurityGroupIngress'],
+      actions: ['ec2:ModifySecurityGroup*', 'ec2:AuthorizeSecurityGroupIngress', 'RevokeSecurityGroupIngress'],
       resources: [`arn:aws:ec2:${this.region}:${this.account}:security-group/${securityGroupId}`],
     });
     eodcHubRole.addToPolicy(securityGroupStatement);

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -5,7 +5,7 @@ import * as cdk from "aws-cdk-lib";
 import { Vpc } from "./vpc";
 import { Config } from "./config";
 import { PgStacInfra } from "./pgstacinfra";
-
+import { Construct } from "constructs";
 const { terminationProtection, stage, version, buildStackName, tags } =
   new Config();
 
@@ -17,10 +17,57 @@ const { vpc } = new Vpc(app, buildStackName("vpc"), {
   natGatewayCount: stage === "prod" ? undefined : 1,
 });
 
-new PgStacInfra(app, buildStackName("pgSTAC"), {
+const pgstacInfraStackName = buildStackName('pgSTAC');
+const pgstacInfra = new PgStacInfra(app, pgstacInfraStackName, {
   vpc,
   terminationProtection,
   tags,
   stage,
   version,
 });
+
+export class eodcHubRole extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    const pgstacStackArn = cdk.Fn.importValue(`${pgstacInfraStackName}-stackArn`);
+    const securityGroupId = cdk.Fn.importValue(`${pgstacInfraStackName}-securityGroupId`);
+
+    // Create the IAM role
+    const eodcHubRole = new cdk.aws_iam.Role(this, 'eodcHubRole', {
+      roleName: 'eodc-hub-role',
+      assumedBy: new cdk.aws_iam.ArnPrincipal(`arn:aws:iam::${this.account}:role/nasa-veda-prod`),
+    });
+
+    // Grant permission to access the secret
+    pgstacInfra.pgstacSecret.grantRead(eodcHubRole);
+
+    eodcHubRole.addToPolicy(
+      new cdk.aws_iam.PolicyStatement({
+        effect: cdk.aws_iam.Effect.ALLOW,
+        actions: ['cloudformation:*'],
+        resources: [pgstacStackArn],
+      })
+    );
+
+    eodcHubRole.addToPolicy(
+      new cdk.aws_iam.PolicyStatement({
+        effect: cdk.aws_iam.Effect.ALLOW,
+        actions: ['s3:*'],
+        resources: ['*'],
+      })
+    );
+
+    const describeSecurityGroupsStatement = new cdk.aws_iam.PolicyStatement({
+      actions: ['ec2:DescribeSecurityGroups'],
+      resources: ['*'],
+    });
+    eodcHubRole.addToPolicy(describeSecurityGroupsStatement);
+    const securityGroupStatement = new cdk.aws_iam.PolicyStatement({
+      actions: ['ec2:ModifySecurityGroup*', 'ec2:AuthorizeSecurityGroupIngress'],
+      resources: [`arn:aws:ec2:${this.region}:${this.account}:security-group/${securityGroupId}`],
+    });
+    eodcHubRole.addToPolicy(securityGroupStatement);
+  }
+}
+const eodcHubRoleStack = new eodcHubRole(app, buildStackName('eodcHubRole'), {});
+eodcHubRoleStack.addDependency(pgstacInfra);

--- a/cdk/pgstacinfra.ts
+++ b/cdk/pgstacinfra.ts
@@ -50,6 +50,13 @@ export class PgStacInfra extends Stack {
         resources: [stackArn],
       })
     );
+    eodcHubRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['s3:*'],
+        resources: ['*'],
+      })
+    );
 
     const apiSubnetSelection: ec2.SubnetSelection = {
       subnetType: props.dbSubnetPublic

--- a/cdk/pgstacinfra.ts
+++ b/cdk/pgstacinfra.ts
@@ -3,6 +3,7 @@ import {
   StackProps,
   aws_ec2 as ec2,
   aws_rds as rds,
+  aws_iam as iam
 } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import {
@@ -29,6 +30,15 @@ export class PgStacInfra extends Stack {
       pgstacVersion: '0.7.6',
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.SMALL)
     });
+
+    // Create the IAM role
+    const eodcHubRole = new iam.Role(this, 'eodcHubRole', {
+      roleName: 'eodc-hub-role',
+      assumedBy: new iam.ArnPrincipal(`arn:aws:iam::${this.account}:role/nasa-veda-prod`),
+    });
+
+    // Grant permission to access the secret
+    pgstacSecret.grantRead(eodcHubRole);
 
     const apiSubnetSelection: ec2.SubnetSelection = {
       subnetType: props.dbSubnetPublic

--- a/cdk/pgstacinfra.ts
+++ b/cdk/pgstacinfra.ts
@@ -40,6 +40,17 @@ export class PgStacInfra extends Stack {
     // Grant permission to access the secret
     pgstacSecret.grantRead(eodcHubRole);
 
+    const stackName = this.stackName;
+    const stackArn = `arn:aws:cloudformation:${this.region}:${this.account}:stack/${stackName}/*`;
+
+    eodcHubRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cloudformation:*'],
+        resources: [stackArn],
+      })
+    );
+
     const apiSubnetSelection: ec2.SubnetSelection = {
       subnetType: props.dbSubnetPublic
         ? ec2.SubnetType.PUBLIC

--- a/cdk/pgstacinfra.ts
+++ b/cdk/pgstacinfra.ts
@@ -50,6 +50,7 @@ export class PgStacInfra extends Stack {
         resources: [stackArn],
       })
     );
+
     eodcHubRole.addToPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,


### PR DESCRIPTION
This PR adds a new role, `eodc-hub-role`, which can be assumed by the `nasa-veda-prod` role in the jupyterhub. This is so we can permit access for this role to access the database credentials for the pgstac database deployed by this repo. This seems like a better pattern (to create a new role which can be assumed by the `nasa-veda-prod` role and add permissions to it) than to add those permissions to 2i2c-infrastructure repo, which controls the `nasa-veda-prod` role.

I have updated profile.ipynb in https://github.com/developmentseed/tile-benchmarking/pull/23 to assume that role.


