### PR TITLE
Render existing results in a quarto site

### DIFF
--- a/.github/workflows/quarto-publish.yaml
+++ b/.github/workflows/quarto-publish.yaml
@@ -1,0 +1,30 @@
+# Publish Quarto Book
+# https://github.com/quarto-dev/quarto-actions/blob/v2.1.3/examples/example-01-basics.md
+name: Render and Publish
+
+# Only run for pushes to the main branch
+on:
+  push:
+    branches: main
+  # Runs for pull requests should be disabled other than for testing purposes
+  pull_request:
+   branches:
+     - main
+
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Publish to GitHub Pages (and render)
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ cdk.context.json
 03-e2e/urls
 *cache*
 downloaded*results
+
+/.quarto/
+*_cache/
+_site/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,52 @@
+project:
+  type: website
+
+website:
+  page-navigation: true
+  title: "Tile Benchmarking"
+  site-url: "https://developmentseed.org/tile-benchmarking"
+  repo-url: https://github.com/developmentseed/tile-benchmarking"
+  repo-actions: [edit, issue]
+
+  page-footer:
+    right: "This page is built with ❤️ and [Quarto](https://quarto.org/)."
+
+  sidebar:
+    style: "docked"
+    search: true
+    collapse-level: 2
+    contents:
+      - href: index.qmd
+        text: Welcome
+      - section: Dataset preparation
+        contents:
+          - 01-generate-datasets/generate-cmip6-kerchunk.ipynb
+          - 01-generate-datasets/generate-cmip6-pyramid.ipynb
+          - 01-generate-datasets/generate-cmip6-zarr.ipynb
+          - 01-generate-datasets/generate-fake-data-with-chunks.ipynb
+      - section: Tile Generation
+        contents:
+          - 02-run-tests/01-cog-gdal-tests.ipynb
+          - 02-run-tests/02-cog-kerchunk-zarr.ipynb
+          - 02-run-tests/03-chunk-size.ipynb
+          - 02-run-tests/04-number-of-spatial-chunks.ipynb
+          - 02-run-tests/05-cmip6-pyramid.ipynb
+          - 02-run-tests/06-cmr-netcdf.ipynb
+      - section: Load testing
+        contents:
+          - 03-e2e/caching-strategies-report.ipynb
+          - 03-e2e/compare-dev-feature.ipynb
+          - 03-e2e/compare-prod-dev.ipynb
+
+format:
+  html:
+    theme:
+      light: [cosmo]
+      dark: [cosmo, theme-dark.scss]
+    code-copy: true
+    code-overflow: wrap
+    css: styles.css
+    toc: true
+    toc-depth: 3
+filters:
+  - quarto

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,30 @@
+---
+title: "Tile Benchmarking"
+subtitle: "Benchmarking titiler plugins"
+---
+
+## Welcome {#welcome}
+
+This site contains benchmarking results for [titiler-xarray](https://github.com/developmentseed/titiler-xarray), [titiler-pgstac](https://github.com/stac-utils/titiler-pgstac), and [titiler-cmr](https://github.com/developmentseed/titiler-cmr).
+
+### Environment Setup
+
+It is recommended to run this project on the [VEDA JupyterHub](https://nasa-veda.2i2c.cloud/) if using datasets generated in `01-generate-datasets/`. See instructions on getting an account on the [VEDA JupyterHub docs page](https://nasa-impact.github.io/veda-docs/services/jupyterhub.html).
+
+It is the intention of this project that it can also be used to benchmark tiling for arbitrary zarr datasets. Examples are forthcoming.
+
+Use the `requirements.txt` or `environment.yaml` to setup a python environment.
+
+```
+mamba env create -f environment.yaml
+mamba activate tile-benchmarking
+```
+
+
+### Contents
+
+The contents are broken into three sections:
+
+1. Dataset preparation - prepare datasets for testing titiler-xarray and titiler-pgstac.
+2. Tile generation - test the time required to generate individual tiles.
+3. Load testing - use locust and siege to simulate multiple users requesting tiles simultaneously.

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,18 @@
+/* css styles */
+
+.sidebar-logo {
+    max-width: 150px;
+  }
+
+  .sidebar-title {
+    font-size: 1.7rem;
+  }
+
+  .platform-table td {
+    vertical-align: middle;
+  }
+
+  .platform-table td > div.sourceCode {
+    margin-top: 0.3rem;
+    margin-bottom: 0.3rem;
+  }


### PR DESCRIPTION
This PR builds the notebooks into a quarto website to make it simpler to review the results.