### PR TITLE
Update and rename deploy.yml to deploy-pgstac.yml

### DIFF
--- a/.github/workflows/deploy-pgstac.yml
+++ b/.github/workflows/deploy-pgstac.yml
@@ -1,9 +1,6 @@
 name: Deploy pgSTAC to AWS
 
 on:
-  push:
-    branches:
-      - main
   # enable a workflow to be triggered manually
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This PR removes the trigger to deploy pgstac on pushes to main. I am making this change because we are not currently using this test pgstac instance.